### PR TITLE
minDate and maxDate in documentations caused error

### DIFF
--- a/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
+++ b/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
@@ -86,8 +86,8 @@ providers: [{provide: NgbDateParserFormatter, useClass: YourOwnParserFormatter}]
 const isDisabled = (date: NgbDateStruct, current: {month: number}) => day.date === 13;
 `,
   disablingHTML: `
-<ngb-datepicker [minDate]="{year: 2010, month: 1, day, 1}"
-                [maxDate]="{year: 2048, month 12, day, 31}"
+<ngb-datepicker [minDate]="{year: 2010, month: 1, day: 1}"
+                [maxDate]="{year: 2048, month: 12, day: 31}"
                 [markDisabled]="isDisabled">
 </ngb-datepicker>
 `,


### PR DESCRIPTION
the page here: https://ng-bootstrap.github.io/#/components/datepicker/overview has some invalid json in the minDate and maxDate boxes. This change should fix it

Before submitting a pull request, please make sure you have at least performed the following:

 - [] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [] built and tested the changes locally.
 - [] added/updated any applicable tests.
 - [] added/updated any applicable API documentation.
 - [] added/updated any applicable demos.
